### PR TITLE
Parse ImageDescription and ignore some tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ hms:
 		--bucket-type aws \
 		--comprehend_profile htan-dev \
 		--profile sandbox-developer \
+		--prefix imaging_level_2 \ 
 		--comprehend_profile htan-dev \
 		> outputs/hms_output.tsv
 

--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,51 @@
 
 # SCRIPT (Method 1)
 # aws_detect_pii.py functionality
-deid: deid_ohsu deid_washu
+deid: ohsu hms washu vanderbilt
 
 # For targeting or ignore a specific prefix to identify use
 # add --prefix <target_prefix>
 # or add --ignore-prefix <h_and_e>
-deid_ohsu:
+ohsu:
 	python scripts/aws_detect_pii.py \
 		-b htan-dcc-ohsu \
 		--bucket-type aws \
 		--profile sandbox-developer \
-		--comprehend_profile htan-dev-admin \
+		--prefix imaging_level_2
+		--comprehend_profile htan-dev \
 		> outputs/test_ohsu_output.tsv
 
-deid_washu:
+hms:
+	python scripts/aws_detect_pii.py \
+		-b htan-dcc-hms \
+		--bucket-type aws \
+		--profile sandbox-developer \
+		--comprehend_profile htan-dev \
+		> outputs/test_ohsu_output.tsv
+
+washu:
 	python scripts/aws_detect_pii.py \
 		-b htan-dcc-washu \
 		--bucket-type gcs \
-		--profile htan-gcs \
-		--comprehend_profile htan-dev-admin \
+		--profile htan-dcc-gcs \
+		--prefix h_and_e
+		--comprehend_profile htan-dev \
 		> outputs/test_washu_output.tsv
+	python scripts/aws_detect_pii.py \
+		-b htan-dcc-washu \
+		--bucket-type gcs \
+		--profile htan-dcc-gcs \
+		--prefix imaging_level_2
+		--comprehend_profile htan-dev \
+		> outputs/test_washu_output.tsv
+
+vanderbilt:
+	python scripts/aws_detect_pii.py \
+		-b htan-dcc-vanderbilt \
+		--bucket-type aws \
+		--profile sandbox-developer \
+		--comprehend_profile htan-dev \
+		> outputs/test_ohsu_output.tsv
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ hms:
 		--bucket-type aws \
 		--comprehend_profile htan-dev \
 		--profile sandbox-developer \
-		--prefix imaging_level_2 \ 
+		--prefix imaging_level_2 \
 		--comprehend_profile htan-dev \
 		> outputs/hms_output.tsv
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ ohsu:
 		-b htan-dcc-ohsu \
 		--bucket-type aws \
 		--profile sandbox-developer \
-		--prefix imaging_level_2
+		--prefix imaging_level_2 \
 		--comprehend_profile htan-dev \
 		> outputs/test_ohsu_output.tsv
 
@@ -19,6 +19,7 @@ hms:
 	python scripts/aws_detect_pii.py \
 		-b htan-dcc-hms \
 		--bucket-type aws \
+		--comprehend_profile htan-dev \
 		--profile sandbox-developer \
 		--comprehend_profile htan-dev \
 		> outputs/test_ohsu_output.tsv
@@ -28,14 +29,14 @@ washu:
 		-b htan-dcc-washu \
 		--bucket-type gcs \
 		--profile htan-dcc-gcs \
-		--prefix h_and_e
+		--prefix h_and_e \
 		--comprehend_profile htan-dev \
 		> outputs/test_washu_output.tsv
 	python scripts/aws_detect_pii.py \
 		-b htan-dcc-washu \
 		--bucket-type gcs \
 		--profile htan-dcc-gcs \
-		--prefix imaging_level_2
+		--prefix imaging_level_2 \ 
 		--comprehend_profile htan-dev \
 		> outputs/test_washu_output.tsv
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ ohsu:
 		--profile sandbox-developer \
 		--prefix imaging_level_2 \
 		--comprehend_profile htan-dev \
-		> outputs/test_ohsu_output.tsv
+		> outputs/ohsu_output.tsv
 
 hms:
 	python scripts/aws_detect_pii.py \
@@ -22,7 +22,7 @@ hms:
 		--comprehend_profile htan-dev \
 		--profile sandbox-developer \
 		--comprehend_profile htan-dev \
-		> outputs/test_ohsu_output.tsv
+		> outputs/hms_output.tsv
 
 washu:
 	python scripts/aws_detect_pii.py \
@@ -31,14 +31,14 @@ washu:
 		--profile htan-dcc-gcs \
 		--prefix h_and_e \
 		--comprehend_profile htan-dev \
-		> outputs/test_washu_output.tsv
+		> outputs/washu_he_output.tsv
 	python scripts/aws_detect_pii.py \
 		-b htan-dcc-washu \
 		--bucket-type gcs \
 		--profile htan-dcc-gcs \
 		--prefix imaging_level_2 \ 
 		--comprehend_profile htan-dev \
-		> outputs/test_washu_output.tsv
+		> outputs/washu_imc_output.tsv
 
 vanderbilt:
 	python scripts/aws_detect_pii.py \
@@ -46,7 +46,7 @@ vanderbilt:
 		--bucket-type aws \
 		--profile sandbox-developer \
 		--comprehend_profile htan-dev \
-		> outputs/test_ohsu_output.tsv
+		> outputs/vanderbilt_output.tsv
 
 
 

--- a/scripts/aws_detect_pii.py
+++ b/scripts/aws_detect_pii.py
@@ -213,6 +213,8 @@ def detect_pii(session, data: str, chunk_size: int = 4096) -> List[str]:
 
     results = []
     for i, chunk in enumerate(split_data):
+        if len(chunk) > 0:
+            continue
         pii_results = comprehend.detect_pii_entities(Text=chunk, LanguageCode='en')
         entities = pii_results.get('Entities', None)
         if not entities:

--- a/scripts/aws_detect_pii.py
+++ b/scripts/aws_detect_pii.py
@@ -1,4 +1,3 @@
-import sys
 import argparse
 import io
 import logging
@@ -215,7 +214,8 @@ def detect_pii(session, data: str, chunk_size: int = 4096) -> List[str]:
     for i, chunk in enumerate(split_data):
         if len(chunk) == 0:
             continue
-        pii_results = comprehend.detect_pii_entities(Text=chunk, LanguageCode='en')
+        pii_results = comprehend.detect_pii_entities(
+            Text=chunk, LanguageCode='en')
         entities = pii_results.get('Entities', None)
         if not entities:
             continue
@@ -330,7 +330,7 @@ def main():
 
 
         try:
-            if s3Key.endswith('.txt') or s3Key.endswith('.csv'):
+            if s3Key.endswith('.xxx') or s3Key.endswith('.xxx'):
                 logger.info(f"Retrieved: {s3Bucket},{s3Key}")
                 if bucket_type == 'gcs':
                     s3Key = s3Key.replace('+', ' ')
@@ -356,7 +356,7 @@ def main():
                 with TiffFile(S3File(obj)) as tif:
                     tags = tif.pages[0].tags
                     # Call detect per image tag
-                    logger.info("Checking {} ImageDescription tags".format(str(len(tags.values()))))
+                    logger.info("Checking {} TIFF tags".format(str(len(tags.values()))))
                     for tag in tags.values():
 
                         if any(s in tag.name for s in ignored_tags):

--- a/scripts/aws_detect_pii.py
+++ b/scripts/aws_detect_pii.py
@@ -213,7 +213,7 @@ def detect_pii(session, data: str, chunk_size: int = 4096) -> List[str]:
 
     results = []
     for i, chunk in enumerate(split_data):
-        if len(chunk) > 0:
+        if len(chunk) == 0:
             continue
         pii_results = comprehend.detect_pii_entities(Text=chunk, LanguageCode='en')
         entities = pii_results.get('Entities', None)

--- a/scripts/aws_detect_pii.py
+++ b/scripts/aws_detect_pii.py
@@ -374,21 +374,25 @@ def main():
                     if description[:7] == 'Aperio ':
                         logger.info("Parsing SVS image description to dict")
                         description = tifffile.tifffile.svs_description_metadata(description)
+                        description = flatten(description)
                     elif description[-4:] == 'OME>':
                         logger.info("Parsing OME-XML image description to dict")
                         description = tifffile.xml2dict(description)
+                        description = flatten(description)
                     elif description[1:] == '<' and description[-1:] == '>':
                         logger.info("Parsing XML image description to dict")
                         description = tifffile.xml2dict(description)
+                        description = flatten(description)
                     elif description[:7] == 'ImageJ=':
                         logger.info("Parsing ImageJ image description to dict")
                         description = tifffile.imagej_description_metadata(description)
+                        description = flatten(description)
                     else:
                         try:
                             description = tifffile.tifffile.json_description_metadata(description)
+                            description = flatten(description)
                         except:
                             description = description
-                    description = flatten(description)
                     logger.info("Checking {} ImageDescription tags".format(str(len(description.items()))))
                     for d_tag, d_value in description.items():
                         #logger.info("inspecting tag: " + str(d_tag) + " : " + str(d_value))

--- a/scripts/aws_detect_pii.py
+++ b/scripts/aws_detect_pii.py
@@ -274,7 +274,7 @@ def process_args():
     parser.add_argument('-cp', '--comprehend_profile', default='default', type=str, help='AWS profile to use for Comprehend API')
     parser.add_argument('-pr', '--prefix', default='/', help='If you do not supply a prefix, we will iterate through all bucket contents')
     parser.add_argument('-i', '--ignore-prefix', help='We will ignore keys that start with this prefix')
-    parser.add_argument('-l', '--log-level', default=logging.WARNING)
+    parser.add_argument('-l', '--log-level', default=logging.INFO)
     return parser.parse_args()
 
 def main():
@@ -355,7 +355,7 @@ def main():
 
                         else: 
                             pii_entities, stats = detect_pii(comprehend_session, str(tag.value))
-                            logger.info("Size/Chunks/Entities:{}".format(stats))
+                            #logger.info("Size/Chunks/Entities:{}".format(stats))
                         # Write out each line
                             for entity in pii_entities:
                                 result = json.dumps(entity[1])
@@ -363,16 +363,16 @@ def main():
                     # Call detect per image description tag
                     description = tif.pages[0].description
                     if description[:7] == 'Aperio ':
-                        #print("Parsing SVS image description to dict")
+                        logger.info("Parsing SVS image description to dict")
                         description = tifffile.tifffile.svs_description_metadata(description)
                     elif description[-4:] == 'OME>':
-                        #print("Parsing OME-XML image description to dict")
+                        logger.info("Parsing OME-XML image description to dict")
                         description = tifffile.xml2dict(description)
                     elif description[1:] == '<' and description[-1:] == '>':
-                        #print("Parsing XML image description to dict")
+                        logger.info("Parsing XML image description to dict")
                         description = tifffile.xml2dict(description)
                     elif description[:7] == 'ImageJ=':
-                        #print("Parsing ImageJ image description to dict")
+                        logger.info("Parsing ImageJ image description to dict")
                         description = tifffile.imagej_description_metadata(description)
                     else:
                         try:
@@ -381,9 +381,9 @@ def main():
                             description = description
                     description = flatten(description)
                     for d_tag, d_value in description.items():
-                        #print("inspecting tag: " + str(d_tag) + " : " + str(d_value))
+                        #logger.info("inspecting tag: " + str(d_tag) + " : " + str(d_value))
                         d_pii_entities, d_stats = detect_pii(comprehend_session, str(d_value))
-                        logger.info("Size/Chunks/Entities:{}".format(d_stats))
+                        #logger.info("Size/Chunks/Entities:{}".format(d_stats))
                         for d_entity in d_pii_entities:
                             result = json.dumps(d_entity[1])
                             print(f'{s3Bucket}\t {s3Key}\t ImageDescription_{d_tag}\t {d_value}\t {result}')

--- a/scripts/aws_detect_pii.py
+++ b/scripts/aws_detect_pii.py
@@ -331,7 +331,7 @@ def main():
             if s3Key.endswith('.txt') or s3Key.endswith('.csv'):
                 logger.info(f"Retrieved: {s3Bucket},{s3Key}")
                 if bucket_type == 'gcs':
-                    ks3Keyey = keys3Key.replace('+', ' ')
+                    s3Key = s3Key.replace('+', ' ')
                 obj = s3.Object(bucket_name=s3Bucket, key=s3Key)
                 data = obj.get()['Body'].read().decode('utf-8')
 
@@ -346,7 +346,7 @@ def main():
 
             elif s3Key.endswith('.ome.tiff') or s3Key.endswith('.ome.tif') or s3Key.endswith('.tif') or s3Key.endswith('.svs'):
                 if bucket_type == 'gcs':
-                    ks3Keyey = keys3Key.replace('+', ' ')
+                    s3Key = s3Key.replace('+', ' ')
                 obj = s3.Object(bucket_name=s3Bucket, key=s3Key)
                 logger.info(f"Retrieved: {s3Bucket},{s3Key}")
                 logger.debug(obj)

--- a/scripts/aws_detect_pii.py
+++ b/scripts/aws_detect_pii.py
@@ -390,7 +390,10 @@ def main():
                     logger.info("Checking {} ImageDescription tags".format(str(len(description.items()))))
                     for d_tag, d_value in description.items():
                         #logger.info("inspecting tag: " + str(d_tag) + " : " + str(d_value))
-                        d_pii_entities, d_stats = detect_pii(comprehend_session, str(d_value))
+                        try: 
+                            d_pii_entities, d_stats = detect_pii(comprehend_session, str(d_value))
+                        except: 
+                            None
                         #logger.info("Size/Chunks/Entities:{}".format(d_stats))
                         for d_entity in d_pii_entities:
                             result = json.dumps(d_entity[1])


### PR DESCRIPTION
This PR adds the following features

- Ignores the following tags
  - "JPEGTables",
  - "InterColorProfile",
  - "StripOffsets",
  - "StripByteCounts",
  - "TileOffsets",
  - "TileByteCounts",
  - "ImageWidth",
  - "ImageHeight"

- Parses Aperio, OME-XML, XML, JSON and ImageJ formatted structured image descriptions into seperate key-value pairs for passing to AWS comprehend

- Exports the tag value in the output
